### PR TITLE
remove double definition of dependancy on httparty

### DIFF
--- a/travlrmap.gemspec
+++ b/travlrmap.gemspec
@@ -21,7 +21,6 @@ Gem::Specification::new do |spec|
 
   spec.add_dependency 'sinatra'
   spec.add_dependency 'bundler'
-  spec.add_dependency 'httparty'
   spec.add_dependency 'ruby_kml'
   spec.add_dependency 'httparty'
   spec.add_dependency 'nokogiri'


### PR DESCRIPTION
Hello,

Build of travlrmap gem failed due to double dependancy on httparty.
I just removed one of the line.

Thanks for sharing this nice application
