### PR TITLE
force UTF-8 encoding for source to ensure ruby 1.9.3 compatibility

### DIFF
--- a/lib/travlrmap/point.rb
+++ b/lib/travlrmap/point.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Travlrmap
   class Point
     def initialize(from, types, type=:json)

--- a/lib/travlrmap/points.rb
+++ b/lib/travlrmap/points.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Travlrmap
   class Points
     def initialize(types, sets, map)

--- a/lib/travlrmap/sinatra_app.rb
+++ b/lib/travlrmap/sinatra_app.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Travlrmap
   class SinatraApp < ::Sinatra::Base
     def initialize(config)

--- a/lib/travlrmap/util.rb
+++ b/lib/travlrmap/util.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Travlrmap
   module Util
     def self.kml_style_url(key, type)

--- a/lib/travlrmap/version.rb
+++ b/lib/travlrmap/version.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Travlrmap
   VERSION = "1.4.0"
 end


### PR DESCRIPTION
Exception is raised when using ruby 1.9.3 and some french characters (non-ascii).
By adding comment with utf-8 encoding in all sources, it solve the issue.
