### PR TITLE
add ability to rely on Web server basic authentication for geocode

### DIFF
--- a/config/travlrmap.yaml.dist
+++ b/config/travlrmap.yaml.dist
@@ -22,6 +22,8 @@
   :map_types: [hybrid, roadmap, satellite, terrain, osm]
   :default_map_type: roadmap
 
+  #:allow_webserver_authent: true
+
   #:admin_user: admin
   #:admin_salt: d34fda332c9a0f8997d33db8172b67b1a319fd79d108568aa4fbdb2b
   #:admin_hash: 267d09bb203ec5c9a20eb7dbc1a

--- a/lib/travlrmap/sinatra_app.rb
+++ b/lib/travlrmap/sinatra_app.rb
@@ -37,6 +37,7 @@ module Travlrmap
       alias_method :h, :escape_html
 
       def protected!
+        return if (@map[:allow_webserver_authent] && ENV.key?('REMOTE_USER') && !ENV['REMOTE_USER'].empty?)
         return if authorized?
         headers['WWW-Authenticate'] = 'Basic realm="Restricted Area"'
         halt(401, "Not authorized\n")


### PR DESCRIPTION
This patch add a new option in map: allow_webserver_authent
If it is set to true, then we check if environment variable REMOTE_USER is set.
It is is set, then we consider that we are authenticated.

It avoids infinite loop when installing travlramp behing an Apache basic authentication.

PS: I did not find where it is possible to edit the site 'https://ripienaar.github.io/travlrmap/' to add the new option. Let me know if I missed something.
